### PR TITLE
Exclude GHC < 7.6 because of build failure

### DIFF
--- a/weeder.cabal
+++ b/weeder.cabal
@@ -27,7 +27,7 @@ executable weeder
     main-is:            Main.hs
     hs-source-dirs:     src
     build-depends:
-        base == 4.*,
+        base >= 4.6 && < 5,
         text,
         unordered-containers,
         yaml,


### PR DESCRIPTION
```
src/Hi.hs:12:8:
    Could not find module `GHC.Generics'
    It is a member of the hidden package `ghc-prim'.
    Perhaps you need to add `ghc-prim' to the build-depends in your .cabal file.
    Use -v to see a list of the files searched for.
```

I added revisions on hackage for this.
