### PR TITLE
Reduce allocation by switching from Foundation to Text

### DIFF
--- a/src/Str.hs
+++ b/src/Str.hs
@@ -1,40 +1,27 @@
-{-# LANGUAGE ViewPatterns #-}
-
 module Str(
     Str,
-    linesCR, stripPrefix,
+    linesCR, S.stripPrefix,
     readFileUTF8,
-    S.null, S.isPrefixOf, S.drop, S.span, S.length, S.toList, S.all, S.uncons,
+    S.null, S.isPrefixOf, S.drop, S.span, S.length, toList, S.all, S.uncons,
     ugly, showLength
     ) where
 
-import qualified Foundation as S
-import qualified Foundation.String as S
-import qualified Foundation.IO as S
-import qualified Foundation.Conduit as C
-import qualified Foundation.Conduit.Textual as C
-import Data.Tuple.Extra
+import qualified Data.Text as S
+import qualified Data.Text.IO as S
 
+type Str = S.Text
 
-type Str = S.String
+toList :: Str -> String
+toList = S.unpack
 
-showLength :: S.CountOf a -> String
-showLength (S.CountOf x) = show x
-
-stripPrefix :: Str -> Str -> Maybe Str
-stripPrefix (S.toBytes S.UTF8 -> pre) (S.toBytes S.UTF8 -> x) =
-    if pre `S.isPrefixOf` x then Just $ S.fromBytesUnsafe $ S.drop (S.length pre) x else Nothing
-
-removeR :: Str -> Str
-removeR s | Just (s, c) <- S.unsnoc s, c == '\r' = s
-          | otherwise = s
+showLength :: Int -> String
+showLength = show
 
 linesCR :: Str -> [Str]
-linesCR s = map removeR $ C.runConduitPure (C.yield s C..| C.lines C..| C.sinkList)
+linesCR = S.lines
 
-ugly :: S.Integral a => Integer -> a
-ugly = S.fromInteger
+ugly :: Integral a => Integer -> a
+ugly = fromInteger
 
-
-readFileUTF8 :: FilePath -> IO Str
-readFileUTF8 = fmap (fst3 . S.fromBytes S.UTF8) . S.readFile . S.fromString
+readFileUTF8 :: String -> IO Str
+readFileUTF8 = S.readFile

--- a/weeder.cabal
+++ b/weeder.cabal
@@ -40,7 +40,7 @@ executable weeder
         aeson,
         yaml,
         bytestring,
-        foundation >= 0.0.10,
+        text,
         process >= 1.2.3.0,
         extra
     other-modules:


### PR DESCRIPTION
I saw #25 and decided to try profiling the alternative strings in the `str` directory while running weeder on https://github.com/barrucadu/dejafu, four packages with 51 modules between them.  Here's what I found:

| | Time (Real) | Time (User) | Time (Sys) | Total Allocation |
|-|-|-|-|-|
|Str-ByteString.hs|0m34.217s|0m33.771s|0m2.497s|1,668,614,968 bytes|
|Str-Foundation.hs|0m34.499s|0m34.130s|0m2.373s|3,839,080,344 bytes|
|Str-Foundation-Unsafe.hs|0m34.783s|0m34.369s|0m2.379s|3,015,613,200 bytes|
|Str-String.hs|0m39.284s|0m38.590s|0m2.702s|5,528,129,584 bytes|
|Str-Text.hs|0m34.344s|0m33.880s|0m2.462s|1,767,357,752 bytes|

Timing results are from compiling without profiling, allocation results are from compiling with `-prof -fprof-auto`, so there may well be some optimisations being defeated.

Text appears to use a little over half the memory of Foundation.Unsafe, with a very similar runtime.

The benchmark scripts are:

**time:**

```bash
#! /usr/bin/env nix-shell
#! nix-shell -i bash --pure  -p 'pkgs.haskellPackages.ghcWithPackages (pkgs: with pkgs; [ hashable unordered-containers yaml cmdargs extra text foundation bytestring ])' -p haskellPackages.stack

for str in str/*.hs; do
  mkdir -p dist/$str
  ghc --make src/Paths.hs $str Main -isrc -outputdir dist/$str -o dist/$str/weeder
  dist/$str/weeder --test || exit 1
done

pushd ../dejafu
stack build
popd

for str in str/*.hs; do
  echo
  echo $str
  time ./dist/$str/weeder ../dejafu/concurrency ../dejafu/dejafu ../dejafu/hunit-dejafu ../dejafu/tasty-dejafu ../dejafu/dejafu-tests >/dev/null
done
```

**allocation:**

```bash
#! /usr/bin/env nix-shell
#! nix-shell -i bash --pure  -p 'pkgs.profiledHaskellPackages.ghcWithPackages (pkgs: with pkgs; [ hashable unordered-containers yaml cmdargs extra text foundation bytestring ])' -p haskellPackages.stack

for str in str/*.hs; do
  mkdir -p dist/$str
  ghc --make src/Paths.hs $str Main -isrc -outputdir dist/$str -o dist/$str/weeder -prof -fprof-auto
  dist/$str/weeder --test || exit 1
done

pushd ../dejafu
stack build
popd

for str in str/*.hs; do
  ./dist/$str/weeder ../dejafu/concurrency ../dejafu/dejafu ../dejafu/hunit-dejafu ../dejafu/tasty-dejafu ../dejafu/dejafu-tests +RTS -p >/dev/null
  mv *.prof dist/$str/
done
```

(where `pkgs.profiledHaskellPackages` is the Nix Haskell package set with libraries compiled with profiling turned on)