### PR TITLE
Parse caret version selector in cabal files

### DIFF
--- a/src/Cabal.hs
+++ b/src/Cabal.hs
@@ -135,7 +135,7 @@ parseSection typ xs = mempty{cabalSectionType=typ} <> parse xs
         trimEqual xs = map (drop n) xs
             where n = minimum $ 0 : map (length . takeWhile isSpace) xs
         listSplit = concatMap (wordsBy (`elem` " ,"))
-        parsePackage = dropSuffix "-any" . filter (not . isSpace) . takeWhile (`notElem` "=><")
+        parsePackage = dropSuffix "-any" . filter (not . isSpace) . takeWhile (`notElem` "^=><")
 
         f (keyValues -> (k,vs)) = case k of
             "if" -> parse vs

--- a/test/foo/foo.cabal
+++ b/test/foo/foo.cabal
@@ -6,7 +6,7 @@ version:            0
 library
     default-language:   Haskell2010
     hs-source-dirs:     src
-    build-depends:      base, cmdargs > 0.0, process < 1000, extra -any, array, template-haskell
+    build-depends:      base ^>= 4.10, cmdargs > 0.0, process < 1000, extra -any, array, template-haskell
     build-tools:        alex
     exposed-modules:
         Library1


### PR DESCRIPTION
Cabal supports a caret version selector, e.g. `base ^>= 4.10`. Before the caret was parsed as part of the package name.