### PR TITLE
Add test case for Cabal internal libraries

### DIFF
--- a/test/.weeder.yaml
+++ b/test/.weeder.yaml
@@ -77,3 +77,24 @@
       - module:
         - name: Dir.Unused
         - identifier: unused
+
+## TODO: These false positives are due to the use of Cabal internal
+## libraries, which are not yet supported by Weeder.
+- package:
+  - name: two
+  - section:
+    - name: exe:two
+    - message:
+      - name: Redundant build-depends entry
+      - depends: cli
+  - section:
+    - name: library
+    - message:
+      - name: Module not compiled
+      - module: CLI
+    - message:
+      - name: Redundant build-depends entry
+      - depends:
+        - cmdargs
+        - data-default
+        - two

--- a/test/stack.yaml
+++ b/test/stack.yaml
@@ -1,6 +1,6 @@
 # Upgrade the resolver semi-regularly so that in Appveyor the "stack init"
 # and the below resolver can share at least the compiler
 resolver: nightly-2018-08-21
-packages: [foo, bar, baz]
+packages: [foo, bar, baz, two]
 ghc-options:
   "$locals": -Werror -Wunused-binds -Wunused-imports -Wno-missing-home-modules -optP-Wno-nonportable-include-path

--- a/test/two/Setup.hs
+++ b/test/two/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/test/two/app/Main.hs
+++ b/test/two/app/Main.hs
@@ -1,0 +1,8 @@
+module Main where
+
+import qualified Data.Text.IO as T
+import CLI (parseArgs)
+import Common
+
+main :: IO ()
+main = T.putStrLn =<< fmap (helloMessage . hello) parseArgs

--- a/test/two/cli/CLI.hs
+++ b/test/two/cli/CLI.hs
@@ -1,0 +1,10 @@
+module CLI (parseArgs, sample) where
+
+import Common
+import System.Console.CmdArgs
+
+sample = Sample{hello = mempty &= help "World argument" &= opt "world"}
+         &= summary "Sample v1"
+
+parseArgs :: IO Sample
+parseArgs = cmdArgs sample

--- a/test/two/src/Common.hs
+++ b/test/two/src/Common.hs
@@ -1,0 +1,9 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+
+module Common (Sample(..), helloMessage) where
+
+import Data.Data (Data, Typeable)
+import Data.Text (Text)
+import Impl
+
+data Sample = Sample {hello :: Text} deriving (Show, Data, Typeable)

--- a/test/two/src/Impl.hs
+++ b/test/two/src/Impl.hs
@@ -1,0 +1,9 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Impl (helloMessage) where
+
+import Data.Semigroup ((<>))
+import Data.Text (Text)
+
+helloMessage :: Text -> Text
+helloMessage w = "Hello, " <> w <> "!"

--- a/test/two/two.cabal
+++ b/test/two/two.cabal
@@ -1,0 +1,25 @@
+cabal-version:       2.2
+name:                two
+version:             0
+
+common same
+  build-depends:      base >=4.11 && <4.13, text
+  default-language:   Haskell2010
+
+library
+  import:             same
+  exposed-modules:    Common
+  other-modules:      Impl
+  hs-source-dirs:     src
+
+library cli
+  import:             same
+  build-depends:      two, cmdargs > 0.0, data-default
+  exposed-modules:    CLI
+  hs-source-dirs:     cli
+
+executable two
+  import:             same
+  main-is:            Main.hs
+  hs-source-dirs:     app
+  build-depends:      two, cli


### PR DESCRIPTION
Hi, I'm trying to use Weeder with a project that has [Cabal internal libraries](https://www.haskell.org/cabal/users-guide/developing-packages.html#sublibs). This pull request has an example test case. I suppose they are not yet supported by Weeder, but haven't looked into it closely. Do you know of any workarounds I could try?
